### PR TITLE
Fixes bug on function get_all_elements_file

### DIFF
--- a/api/design_wizard.py
+++ b/api/design_wizard.py
@@ -92,9 +92,10 @@ class PythonDW:
 
     def get_all_elements_file(self, key):
         list_elements = []
-        for node in ast.walk(self.ast_tree):
-            if isinstance(node, self.ast_elements_dict[key]):
-                list_elements.append(node)
+        if key in self.ast_elements_dict:
+            for node in ast.walk(self.ast_tree):
+                if isinstance(node, self.ast_elements_dict[key]):
+                    list_elements.append(node)
         return list_elements
 
     def get_everything(self):


### PR DESCRIPTION
The function was trying to check the instance of elements in the ast dictionary by key without first verifying whether that key existed, which caused an error when it was the case.
This PRs adds an additional verification to prevent that exception to happen.